### PR TITLE
Fix missing required version field in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,103 @@
 {
   "name": "ghost-storage-adapter-ipfs",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fission-suite/client": "^2.0.5",
+        "ghost-storage-base": "0.0.5"
+      },
+      "engines": {
+        "node": ">12"
+      }
+    },
+    "node_modules/@fission-suite/client": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@fission-suite/client/-/client-2.0.5.tgz",
+      "integrity": "sha512-3bZ3trZTZ3lqJ1iKdJ/tgxm3Zzh5mukYk0obakraNrf3dG6woWCT4nyQxxEI5fFDjxaVp5Dw2QCUrok3M7OL1w==",
+      "dependencies": {
+        "axios": "^0.19.0",
+        "dotenv": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dependencies": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/ghost-storage-base": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ghost-storage-base/-/ghost-storage-base-0.0.5.tgz",
+      "integrity": "sha512-uNOFYmHHfp9aTs6Fg4O9NQUi478DUpA4r/hckHOJNHfa29j+GHrKFHEVBeqY63Ta8XW+0+u2MZH5VruWRbX9Rg==",
+      "dependencies": {
+        "moment": "2.26.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    }
+  },
   "dependencies": {
     "@fission-suite/client": {
-      "version": "2.0.0-rc",
-      "resolved": "https://registry.npmjs.org/@fission-suite/client/-/client-2.0.0-rc.tgz",
-      "integrity": "sha512-ImEAdnLAGhYN4zfTKi887VKxzz516KT+o95Fwx5xld/KQqOkbDcwNHNzfWoahdlg/uK6d1gunEmwhjTcegVDrw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@fission-suite/client/-/client-2.0.5.tgz",
+      "integrity": "sha512-3bZ3trZTZ3lqJ1iKdJ/tgxm3Zzh5mukYk0obakraNrf3dG6woWCT4nyQxxEI5fFDjxaVp5Dw2QCUrok3M7OL1w==",
       "requires": {
         "axios": "^0.19.0",
         "dotenv": "^8.1.0"
@@ -43,11 +134,11 @@
       }
     },
     "ghost-storage-base": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/ghost-storage-base/-/ghost-storage-base-0.0.3.tgz",
-      "integrity": "sha512-EMQLl9hR6zgjvDENHBH5Icbsf4DdA7n7ABtgCpjRx3BDgBb/tmM3XV97iTpGWZe9KEGKlXN25k8FXIVS2R0Jag==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ghost-storage-base/-/ghost-storage-base-0.0.5.tgz",
+      "integrity": "sha512-uNOFYmHHfp9aTs6Fg4O9NQUi478DUpA4r/hckHOJNHfa29j+GHrKFHEVBeqY63Ta8XW+0+u2MZH5VruWRbX9Rg==",
       "requires": {
-        "moment": "^2.19.3"
+        "moment": "2.26.0"
       }
     },
     "is-buffer": {
@@ -56,9 +147,9 @@
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "private": true,
   "dependencies": {
-    "@fission-suite/client": "^2.0.0-rc",
-    "ghost-storage-base": "0.0.3"
+    "@fission-suite/client": "^2.0.5",
+    "ghost-storage-base": "0.0.5"
   },
   "engines": {
     "node": ">12"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ghost-storage-base": "0.0.3"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">12"
   },
   "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ghost-storage-adapter-ipfs",
+  "version": "1.0.0",
   "description": "A storage adapter for the Ghost blogging platform, so that files and images are stored on IPFS",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
Build for https://github.com/fission-suite/heroku-ipfs-ghost was breaking due to the missing version field. Then because of conflicting requirements with dependencies that use node >14. I went ahead and updated this package's dependencies too, not sure if that's too coarse for a single PR or if I should make multiple ones.